### PR TITLE
🔥  アセットの分岐を削除

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,3 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+Disallow: /

--- a/src/model/assets.ts
+++ b/src/model/assets.ts
@@ -9,16 +9,6 @@ export const assert = (val: boolean, message?: string): void | never => {
 };
 
 export const getAssets = (path: ASSETS): string => {
-    const envMode = process.env.NODE_ENV;
-    const assetsUrl = process.env.REACT_APP_ASSETS_URL;
-
-    if (envMode === "production") {
-        assert(
-            assetsUrl !== undefined,
-            "REACT_APP_ASSETS_URL is undefined.  Check your environment file available",
-        );
-    }
-
     assert(
         (path.match(/\./g) || []).length === 1,
         "Requested asset url is invalid;  The number of file extension (period) is not 1",
@@ -27,12 +17,7 @@ export const getAssets = (path: ASSETS): string => {
         path[1] !== "/",
         "Requested asset url is invalid;  Do not add a leading slash",
     );
-
-    if (envMode === "production") {
-        return `${assetsUrl}/${path}`;
-    } else {
-        return `/assets/${path}`;
-    }
+    return `/assets/${path}`;
 };
 
 export const getImg = (imgPath: IMG): string => {


### PR DESCRIPTION
`wappon-28-assets.cf` の終焉によって, アセットサーバーのアドレスに到達できなくなりました.  
アクセス数も多くならないはずなので, 分岐を削除してつねに origin である Vercel に分岐がいくように変えました.